### PR TITLE
We need to disable the uyuni patch repo for openSUSE 15.5

### DIFF
--- a/roles/server/defaults/main.yml
+++ b/roles/server/defaults/main.yml
@@ -7,25 +7,6 @@ uyuni_core_packages:
   - man
   - firewalld
 
-uyuni_gpg:
-  - https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable/images/repodata/repomd.xml.key
-  - "https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/Patches/openSUSE_Leap_{{ ansible_distribution_version }}/repodata/repomd.xml.key"
-
-uyuni_repos:
-  - url: "https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable/images/repo/Uyuni-Server-POOL-{{ ansible_architecture }}-Media1"
-    name: uyuni-server-stable
-  - url: "https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/Patches/openSUSE_Leap_{{ ansible_distribution_version }}/"
-    name: uyuni-server-patches
-
-uyuni_repo_gpg:
-  - "https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Snapshots:/{{ uyuni_release }}/images/repodata/repomd.xml.key"
-
-uyuni_repo_release:
-  - url: "https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Snapshots:/{{ uyuni_release }}/images/"
-    name: uyuni-server-stable
-  - url: "https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/Patches/openSUSE_Leap_{{ ansible_distribution_version }}/"
-    name: uyuni-server-patches
-
 uyuni_packages:
   - spacewalk-utils
   - spacecmd

--- a/roles/server/tasks/prepare_opensuse_leap.yml
+++ b/roles/server/tasks/prepare_opensuse_leap.yml
@@ -40,14 +40,3 @@
     - uyuni_cefs_setup
     - "ansible_distribution_version == '15.4'"
   become: true
-
-
-  # Disable patch repos as long as no patch repo for 15.5 exists
-- name: Disable Patch Repo for openSUSE 15.5 as long no patch is available
-  community.general.zypper_repository:
-    repo: "https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/Patches/openSUSE_Leap_{{ ansible_distribution_version }}/"
-    name: uyuni-server-patches
-    enabled: False
-  when:
-    - "ansible_distribution_version == '15.5'"
-  become: true

--- a/roles/server/tasks/prepare_opensuse_leap.yml
+++ b/roles/server/tasks/prepare_opensuse_leap.yml
@@ -40,3 +40,14 @@
     - uyuni_cefs_setup
     - "ansible_distribution_version == '15.4'"
   become: true
+
+
+  # Disable patch repos as long as no patch repo for 15.5 exists
+- name: Disable Patch Repo for openSUSE 15.5 as long no patch is available
+  community.general.zypper_repository:
+    repo: "https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/Patches/openSUSE_Leap_{{ ansible_distribution_version }}/"
+    name: uyuni-server-patches
+    enabled: False
+  when:
+    - "ansible_distribution_version == '15.5'"
+  become: true

--- a/roles/server/vars/opensuse_leap-15.5.yml
+++ b/roles/server/vars/opensuse_leap-15.5.yml
@@ -4,13 +4,10 @@ uyuni_pattern:
 
 uyuni_gpg:
   - https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable/images/repodata/repomd.xml.key
-  - "https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/Patches/openSUSE_Leap_{{ ansible_distribution_version }}/repodata/repomd.xml.key"
 
 uyuni_repos:
   - url: "https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable/images/repo/Uyuni-Server-POOL-{{ ansible_architecture }}-Media1"
     name: uyuni-server-stable
-  - url: "https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/Patches/openSUSE_Leap_{{ ansible_distribution_version }}/"
-    name: uyuni-server-patches
 
 uyuni_repo_gpg:
   - "https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Snapshots:/{{ uyuni_release }}/images/repodata/repomd.xml.key"
@@ -18,5 +15,3 @@ uyuni_repo_gpg:
 uyuni_repo_release:
   - url: "https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Snapshots:/{{ uyuni_release }}/images/"
     name: uyuni-server-stable
-  - url: "https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/Patches/openSUSE_Leap_{{ ansible_distribution_version }}/"
-    name: uyuni-server-patches


### PR DESCRIPTION
The simple reason is: This repo does yet not exist

zypper will install all packages in upcoming tasks but with errorcodes over 100 so ansible thinks the installation didnt work
This tasks needs to be removed as soon the patch repo for openSUSE 15.5 exists!

See: https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/Patches/