### PR TITLE
Add and Remove System from Uyuni while Bootsrapping and deleting the client

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+---
+- name: community.general

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 ---
-- name: community.general
+collections:
+  - name: community.general

--- a/roles/client/README.md
+++ b/roles/client/README.md
@@ -13,13 +13,20 @@ No requirements.
 | Variable | Default | Description |
 | -------- | ------- | ----------- |
 | `uyuni_server` | **empty** | Uyuni server hostname or FQDN |
+| `uyuni_username` | **empty** | Uyuni username with Org-Admin Role to accept and delete Systems (Optional) |
+| `uyuni_password` | **empty** | Password for Uyuni Admin User (Optional) |
 | `uyuni_bootstrap_filename` | `(distro)(version).sh` | Bootstrap file to download |
 | `uyuni_bootstrap_folder` | `/opt` | Bootstrap file download folder |
+| `uyuni_bootstrap_accept_minion_key` | False | If the Minion Key should be accepted while Bootstrapping  |
 | `uyuni_client_state` | `present` | Bootstrap (`present`) or remove (`absent`) client |
+| `uyuni_removal_cleanup_minion` | False | If the Host should be deleted from Uyuni when client_stat is absent  |
 
 ## Dependencies
 
-No dependencies.
+Ansible Collection:
+  Name: Community.General
+  Reason: Json Query while Accessing Uyuni API when Bootstrapping or deleting Minions
+  https://docs.ansible.com/ansible/latest/collections/community/general/index.html
 
 ## Example Playbook
 
@@ -44,6 +51,21 @@ Set variables if required, e.g.:
       uyuni_bootstrap_folder: /tmp
 ```
 
+You can also accept the salt Minion Keys on the Uyuni server like this and add Uyuni Admin Credentials:
+
+```yaml
+---
+- hosts: clients
+  roles:
+    - role: stdevel.uyuni.client
+      uyuni_server: uyuni01.evilcorp.lan
+      uyuni_bootstrap_filename: bootstrap-dummy.sh
+      uyuni_bootstrap_folder: /tmp
+      uyuni_bootstrap_accept_minion_key: True
+      uyuni_username: admin
+      uyuni_password: password
+```
+
 To remove `salt-minion` and managed software repositories, set `uyuni_client_state` to `absent`:
 
 ```yaml
@@ -55,6 +77,20 @@ To remove `salt-minion` and managed software repositories, set `uyuni_client_sta
 ```
 
 **NOTE**: This will **not** remove the appropriate system profile from Uyuni/SUSE Manager.
+
+If the System should be removed from Uyuni Server as well, set `uyuni_removal_cleanup_minion` to `True` and add Uyuni Admin Credentials:
+
+```yaml
+---
+- hosts: clients
+  roles:
+    - role: stdevel.uyuni.client
+      uyuni_client_state: absent
+      uyuni_removal_cleanup_minion: True
+      uyuni_server: uyuni01.evilcorp.lan
+      uyuni_username: admin
+      uyuni_password: password
+```
 
 ## License
 

--- a/roles/client/defaults/main.yml
+++ b/roles/client/defaults/main.yml
@@ -1,4 +1,6 @@
 ---
 uyuni_bootstrap_filename: "bootstrap-{{ ansible_distribution | regex_replace(' ', '_') | lower }}{{ ansible_distribution_version }}.sh"
 uyuni_bootstrap_folder: /opt
+uyuni_bootstrap_accept_minion_key: False
 uyuni_client_state: present
+uyuni_removal_cleanup_minion: False

--- a/roles/client/tasks/bootstrap.yml
+++ b/roles/client/tasks/bootstrap.yml
@@ -25,7 +25,7 @@
 
 
 - name: Accept Salt-key on Uyuni Server
-  when: uyuni_removal_cleanup_minion == 'True'
+  when: uyuni_bootstrap_accept_minion_key == 'True'
   block:
     - name: Login to uyuni api
       ansible.builtin.uri:

--- a/roles/client/tasks/bootstrap.yml
+++ b/roles/client/tasks/bootstrap.yml
@@ -1,27 +1,44 @@
 ---
-- name: Check if Uyuni server was set
-  ansible.builtin.fail:
-    msg: Set uyuni_server to a valid server hostname/FQDN
-  when: uyuni_server is undefined
 
-- name: Download Uyuni bootstrap script
-  ansible.builtin.get_url:
-    url: "http://{{ uyuni_server }}/pub/bootstrap/{{ uyuni_bootstrap_filename }}"
-    dest: "{{ uyuni_bootstrap_folder }}/bootstrap.sh"
-    owner: root
-    group: root
-    mode: '0755'
-    force: true
-  become: true
+- name: Bootstrap System via Bootstrap Script
+  block:
+    - name: Check if Uyuni server was set
+      ansible.builtin.fail:
+        msg: Set uyuni_server to a valid server hostname/FQDN
+      when: uyuni_server is undefined
 
-- name: Register with Uyuni
-  ansible.builtin.command: "{{ uyuni_bootstrap_folder }}/bootstrap.sh"
-  args:
-    creates: "{{ uyuni_repo_file }}"
-  become: true
+    - name: Download Uyuni bootstrap script
+      ansible.builtin.get_url:
+        url: "http://{{ uyuni_server }}/pub/bootstrap/{{ uyuni_bootstrap_filename }}"
+        dest: "{{ uyuni_bootstrap_folder }}/bootstrap.sh"
+        owner: root
+        group: root
+        mode: '0755'
+      become: true
 
-- name: Remove downloded bootsrap script
-  ansible.builtin.file:
-    path: "{{ uyuni_bootstrap_folder }}/bootstrap.sh"
-    state: absent
-  become: true
+    - name: Register with Uyuni
+      ansible.builtin.command: /opt/bootstrap.sh
+      args:
+        creates: "{{ uyuni_repo_file }}"
+      become: true
+
+
+
+- name: Accept Salt-key on Uyuni Server
+  when: uyuni_removal_cleanup_minion == 'True'
+  block:
+    - name: Login to uyuni api
+      ansible.builtin.uri:
+        url: 'https://{{ uyuni_server }}/rhn/manager/api/auth/login'
+        method: POST
+        body_format: json
+        body: "{ login: {{ uyuni_username }}, password: {{ uyuni_password }} }"
+      register: sessioncookie
+
+    - name: Accept Salt-Key for Host
+      ansible.builtin.uri:
+        url: 'https://{{ uyuni_server }}/rhn/manager/api/saltkey/accept?minionId={{ ansible_hostname }}'
+        method: POST
+        headers:
+          Content-Type: application/json
+          Cookie: "{{ sessioncookie.cookies_string }}"

--- a/roles/client/tasks/removal.yml
+++ b/roles/client/tasks/removal.yml
@@ -1,24 +1,57 @@
 ---
-- name: Stop services
-  ansible.builtin.service:
-    name: "{{ uyuni_minion_service }}"
-    state: stopped
-    enabled: false
-  register: service_stop
-  failed_when:
-    - service_stop.failed
-    - "'not find' not in service_stop.msg"
-  become: true
+- name: Delete Venv Salt Minion from Host
+  block:
+    - name: Stop services
+      ansible.builtin.service:
+        name: "{{ uyuni_minion_service }}"
+        state: stopped
+        enabled: false
+      register: service_stop
+      failed_when:
+        - service_stop.failed
+        - "'not find' not in service_stop.msg"
+      become: true
 
-- name: Remove packages
-  ansible.builtin.package:
-    name: "{{ uyuni_client_packages }}"
-    state: absent
-  become: true
+    - name: Remove packages
+      ansible.builtin.package:
+        name: "{{ uyuni_client_packages }}"
+        state: absent
+      become: true
 
-- name: Remove directories
-  ansible.builtin.file:
-    path: "{{ item }}"
-    state: absent
-  become: true
-  loop: "{{ uyuni_client_directories }}"
+    - name: Remove directories
+      ansible.builtin.file:
+        path: /tmp/somedir
+        state: absent
+      become: true
+      loop: "{{ uyuni_client_directories }}"
+
+
+- name: Delete System from Uyuni/SUMA Server
+  when: uyuni_bootstrap_accept_minion_key == 'True'
+  block:
+    - name: Login to Uyuni REST API
+      ansible.builtin.uri:
+        url: 'https://{{ uyuni_server }}/rhn/manager/api/auth/login'
+        method: POST
+        body_format: json
+        body: "{ login: {{ uyuni_username }}, password: {{ uyuni_password }} }"
+      register: sessioncookie
+
+    - name: Get ServerID from API
+      ansible.builtin.uri:
+        url: 'https://{{ uyuni_server }}/rhn/manager/api/system/getId?name={{ ansible_hostname }}'
+        method: GET
+        headers:
+          Content-Type: application/json
+          Cookie: "{{ sessioncookie.cookies_string }}"
+      register: systemID
+
+    # Delete System with uid, but dont cleanup the minion. This was already done
+    - name: Delete System from Uyuni without Cleanup based on SystemId
+      ansible.builtin.uri:
+        url: "https://{{ uyuni_server }}/rhn/manager/api/system/deleteSystem?sid={{ item }}&cleanupType=NO_CLEANUP"
+        method: POST
+        headers:
+          Content-Type: application/json
+          Cookie: "{{ sessioncookie.cookies_string }}"
+      loop: "{{ systemID.json | community.general.json_query('result[*].id') }}"

--- a/roles/client/tasks/removal.yml
+++ b/roles/client/tasks/removal.yml
@@ -27,7 +27,7 @@
 
 
 - name: Delete System from Uyuni/SUMA Server
-  when: uyuni_bootstrap_accept_minion_key == 'True'
+  when: uyuni_removal_cleanup_minion == 'True'
   block:
     - name: Login to Uyuni REST API
       ansible.builtin.uri:


### PR DESCRIPTION
With this we have the capability of accepting the salt-key while bootstrapping and removing the System from Uyuni while deleting the minion
The actions are handeled via the rest api. So we need an account with at least org-admin to do this.

This is still in draft, because the "when" condition in the blocks wont work at the moment