### PR TITLE
Return action_id of scheduled task

### DIFF
--- a/plugins/modules/install_patches.py
+++ b/plugins/modules/install_patches.py
@@ -106,14 +106,14 @@ def _install_patches(module, api_instance):
             patches = [x["id"] for x in all_patches]
 
         # install patches
-        api_instance.install_patches(
+        action_id = api_instance.install_patches(
             get_host_id(
                 module.params.get('name'),
                 api_instance
             ),
             patches
         )
-        module.exit_json(changed=True)
+        module.exit_json(changed=True, action_id=action_id)
     except EmptySetException:
         # check if already installed
         if patch_already_installed(

--- a/plugins/modules/install_upgrades.py
+++ b/plugins/modules/install_upgrades.py
@@ -111,14 +111,14 @@ def _install_upgrades(module, api_instance):
                 upgrades = [x["to_package_id"] for x in all_upgrades]
 
         # install upgrades
-        api_instance.install_upgrades(
+        action_id = api_instance.install_upgrades(
             get_host_id(
                 module.params.get('name'),
                 api_instance
             ),
             upgrades
         )
-        module.exit_json(changed=True)
+        module.exit_json(changed=True, action_id=action_id)
     except EmptySetException as err:
         # exit if no upgrades available
         if not upgrades:

--- a/plugins/modules/reboot_host.py
+++ b/plugins/modules/reboot_host.py
@@ -68,13 +68,13 @@ def _reboot_host(module, api_instance):
     Reboots the host
     """
     try:
-        api_instance.reboot_host(
+        action_id = api_instance.reboot_host(
             get_host_id(
                 module.params.get('name'),
                 api_instance
             )
         )
-        module.exit_json(changed=True)
+        module.exit_json(changed=True, action_id=action_id)
     except SSLCertVerificationError:
         module.fail_json(msg="Failed to verify SSL certificate")
     except EmptySetException as err:


### PR DESCRIPTION
This implent the missing feature which is described in that Issue #37. I did some basic testing with this playbook
```
---
- name: Install patches on hosts
  hosts: localhost
  tasks:
    - name: Install patches
      stdevel.uyuni.install_patches:
        uyuni_host: host
        uyuni_user: user
        uyuni_password: pass
        name: target_host
      register: install_patches_result
    - name: Print output
      debug:
        var: install_patches_result
```

The Result looks like this:
```
ok: [localhost] => {
    "install_patches_result": {
        "action_id": [
            89152
        ],
        "changed": true,
        "failed": false
    }
}
```
