### PR TITLE
Make the client task idempotent

### DIFF
--- a/roles/client/tasks/bootstrap.yml
+++ b/roles/client/tasks/bootstrap.yml
@@ -4,7 +4,13 @@
     msg: Set uyuni_server to a valid server hostname/FQDN
   when: uyuni_server is undefined
 
+- name: Check if the uyuni_repo_file exists
+  ansible.builtin.stat:
+      path: "{{ uyuni_repo_file }}"
+  register: stat_uyuni_repo_file
+
 - name: Download Uyuni bootstrap script
+  when: stat_uyuni_repo_file.stat.exists == false
   ansible.builtin.get_url:
     url: "http://{{ uyuni_server }}/pub/bootstrap/{{ uyuni_bootstrap_filename }}"
     dest: "{{ uyuni_bootstrap_folder }}/bootstrap.sh"

--- a/roles/client/tasks/bootstrap.yml
+++ b/roles/client/tasks/bootstrap.yml
@@ -26,7 +26,7 @@
     creates: "{{ uyuni_repo_file }}"
   become: true
 
-- name: Remove downloded bootsrap script
+- name: Remove downloaded bootstrap script
   ansible.builtin.file:
     path: "{{ uyuni_bootstrap_folder }}/bootstrap.sh"
     state: absent


### PR DESCRIPTION
Every time when I run the client Role to bootstrap the server the bootstrap script will be downloaded an deleted. Therefore everytime the playbook seems to change. I added a check for bootstrap script and it will only be downloaded if its not in place