### PR TITLE
Add wait_for_action and full_pkg_update module

### DIFF
--- a/plugins/module_utils/helper_functions.py
+++ b/plugins/module_utils/helper_functions.py
@@ -90,3 +90,11 @@ def _configure_connection(connection_params):
     except Exception as err:
         raise BaseException(f"Failed to create API connection: {err}") from err
     return api_instance
+
+def get_outdated_pkgs(target, api_client):
+    """
+    Ensures that a number of outdated packages is returned
+    """
+    if isinstance(target, int) or target.isdigit():
+        return int(target)
+    return api_client.get_outdated_pkgs(target)

--- a/plugins/module_utils/uyuni.py
+++ b/plugins/module_utils/uyuni.py
@@ -676,20 +676,20 @@ class UyuniAPIClient:
                 f"Generic remote communication error: {err.faultString!r}"
             ) from err
 
-    def get_host_action(self, system_id, task_id):
+    def get_host_action(self, system_id, action_id):
         """
         Retrieves information about a particular host action
 
         :param system_id: profile ID
         :type system_id: int
-        :param task_id: task ID
-        :type task_id: int
+        :param action_id: task ID
+        :type action_id: int
         """
         if not isinstance(system_id, int):
             raise EmptySetException(
                 "No system found - use system profile IDs"
             )
-        if not isinstance(task_id, int):
+        if not isinstance(action_id, int):
             raise EmptySetException(
                 "No task found - use task IDs"
             )
@@ -697,14 +697,14 @@ class UyuniAPIClient:
         try:
             # return particular action
             actions = self.get_host_actions(system_id)
-            action = [x for x in actions if x['id'] == task_id]
+            action = [x for x in actions if x['id'] == action_id]
             if not action:
                 raise EmptySetException("Action not found")
             return action
         except Fault as err:
             if "action not found" in err.faultString.lower():
                 raise EmptySetException(
-                    f"Action not found: {task_id!r}"
+                    f"Action not found: {action_id!r}"
                 ) from err
             raise SessionException(
                 f"Generic remote communication error: {err.faultString!r}"

--- a/plugins/modules/full_pkg_update.py
+++ b/plugins/modules/full_pkg_update.py
@@ -1,0 +1,129 @@
+#!/usr/bin/python
+"""
+Ansible Module tp perform full package update on a managed host
+
+2022 Christian Stankowic
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = '''
+---
+module: full_pkg_update
+short_description: Perform full package update
+description:
+  - Perform full package update on a managed host without any exceptions!
+author:
+  - "Christian Stankowic (@stdevel)"
+extends_documentation_fragment:
+  - stdevel.uyuni.uyuni_auth
+options:
+  name:
+    description: Name or profile ID of the managed host
+    required: True
+    type: str
+'''
+
+EXAMPLES = '''
+- name: Perform full package update
+  stdevel.uyuni.full_pkg_update:
+    uyuni_host: 192.168.1.1
+    uyuni_user: admin
+    uyuni_password: admin
+    name: server.localdomain.loc
+'''
+
+RETURN = '''
+entity:
+  description: State whether package installation was scheduled successfully
+  returned: success
+  type: bool
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ..module_utils.exceptions import EmptySetException, SSLCertVerificationError
+from ..module_utils.helper_functions import _configure_connection, get_host_id, get_outdated_pkgs
+
+def _full_pkg_update(module, api_instance):
+    """
+    Performs full package update on host
+    """
+    # get host id
+    host = get_host_id(module.params.get('name'), api_instance)
+    # is reboot required
+    reboot_req = api_instance.is_reboot_required(host)
+    if reboot_req is True:
+        module.fail_json(msg="Cannot install updates. Host must be rebooted first.")
+    # get number of outdated packages
+    upgrades = get_outdated_pkgs(module.params.get('name'), api_instance)
+    if upgrades == 0:
+        module.exit_json(changed=False)
+    try:
+        # install upgrades
+        action_id = api_instance.full_pkg_update(
+            get_host_id(
+                module.params.get('name'),
+                api_instance
+                )
+      )
+        # wait for all packages to be updated
+        api_instance.wait_for_action(action_id, host)
+        module.exit_json(changed=True, installed_updates=upgrades)
+    except EmptySetException as err:
+        # exit if no upgrades available
+        if not upgrades:
+            module.exit_json(changed=False)
+        # exit if invalid upgrade
+        module.fail_json(msg=f"Upgrade(s) not found or applicable: {err}")
+    except SSLCertVerificationError:
+        module.fail_json(msg="Failed to verify SSL certificate")
+
+def main():
+    """
+    Main functions
+    """
+    argument_spec = dict(
+        uyuni_host=dict(required=True),
+        uyuni_user=dict(required=True),
+        uyuni_password=dict(required=True, no_log=True),
+        uyuni_port=dict(default=443, type='int'),
+        uyuni_verify_ssl=dict(default=True, type='bool'),
+        name=dict(required=True)
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=False
+    )
+
+    module_params = dict(
+        host=module.params.get('uyuni_host'),
+        username=module.params.get('uyuni_user'),
+        password=module.params.get('uyuni_password'),
+        port=module.params.get('uyuni_port'),
+        verify_ssl=module.params.get('uyuni_verify_ssl')
+    )
+
+    api_instance = _configure_connection(module_params)
+    _full_pkg_update(module, api_instance)
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/is_reboot_required.py
+++ b/plugins/modules/is_reboot_required.py
@@ -1,0 +1,111 @@
+#!/usr/bin/python
+"""
+Ansible Module tp perform full package update on a managed host
+
+2022 Christian Stankowic
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = '''
+---
+module: is_reboot_required
+short_description: Check if system requires reboot
+description:
+  - Check if a managed host needs to be rebooted!
+author:
+  - "Christian Stankowic (@stdevel)"
+extends_documentation_fragment:
+  - stdevel.uyuni.uyuni_auth
+options:
+  name:
+    description: Name or profile ID of the managed host
+    required: True
+    type: str
+'''
+
+EXAMPLES = '''
+- name: Check if system requires reboot
+  stdevel.uyuni.is_reboot_required:
+    uyuni_host: 192.168.1.1
+    uyuni_user: admin
+    uyuni_password: admin
+    name: server.localdomain.loc
+'''
+
+RETURN = '''
+entity:
+  description: State whether package host needs reboot or not
+  returned: success
+  type: bool
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ..module_utils.exceptions import SSLCertVerificationError
+from ..module_utils.helper_functions import _configure_connection, get_host_id
+
+def _is_reboot_required(module, api_instance):
+    """
+    Check if host requires a reboot
+    """
+    try:
+        # is reboot required
+        reboot_required = api_instance.is_reboot_required(
+            get_host_id(
+                module.params.get('name'),
+                api_instance
+                )
+      )
+        if reboot_required is True:
+            module.exit_json(changed=True, reboot_required=reboot_required)
+        if reboot_required is False:
+            module.exit_json(changed=False, reboot_required=reboot_required)
+    except SSLCertVerificationError:
+        module.fail_json(msg="Failed to verify SSL certificate")
+
+def main():
+    """
+    Main functions
+    """
+    argument_spec = dict(
+        uyuni_host=dict(required=True),
+        uyuni_user=dict(required=True),
+        uyuni_password=dict(required=True, no_log=True),
+        uyuni_port=dict(default=443, type='int'),
+        uyuni_verify_ssl=dict(default=True, type='bool'),
+        name=dict(required=True)
+    )
+
+    module = AnsibleModule(argument_spec=argument_spec)
+
+    connection_params = dict(
+        host=module.params.get('uyuni_host'),
+        username=module.params.get('uyuni_user'),
+        password=module.params.get('uyuni_password'),
+        port=module.params.get('uyuni_port'),
+        verify_ssl=module.params.get('uyuni_verify_ssl')
+    )
+
+    api_instance = _configure_connection(connection_params)
+    _is_reboot_required(module, api_instance)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This implements the missing wait_for_action feature which is described in that Issue https://github.com/stdevel/ansible-collection-uyuni/issues/38. 

It also implements a module full_pkg_update that is calling the system.schedulePackageUpdate method of Uyuni API. This will trigger a "Package Install/Upgrade scheduled by user" in Uyuni on a given system. The module will wait for the action to be completed and uses the wait_for_action function. The result will contain the number of installed updates.


I did some basic testing with this playbook:

```
---
- name: Cool playbook
  hosts: localhost
  gather_facts: false
  tasks:
    - name: Install upgrades
      stdevel.uyuni.full_pkg_update:
        uyuni_host: host
        uyuni_user: user
        uyuni_password: pass
        name: target_host
        uyuni_verify_ssl: false
      register: full_pkg_update

    - debug: var=full_pkg_update

```

Result:

```
ok: [localhost] => {
    "full_pkg_update": {
        "changed": true,
        "failed": false,
        "installed_updates": 442
    }
}

```
